### PR TITLE
feat: Partial Godot 4 migration

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -6,7 +6,7 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
 _global_script_classes=[ {
 "base": "Area2D",
@@ -60,8 +60,8 @@ Global="*res://src/Global.gd"
 
 [display]
 
-window/size/width=240
-window/size/height=208
+display/window/size/viewport_width=240
+display/window/size/viewport_height=208
 window/size/test_width=720
 window/size/test_height=624
 window/stretch/mode="viewport"
@@ -98,6 +98,7 @@ texture={
 
 [rendering]
 
-quality/2d/use_pixel_snap=true
+rendering/renderer/rendering_method="mobile"
+rendering/2d/snapping/use_gpu_pixel_snap=true
 environment/default_environment="res://default_env.tres"
-quality/dynamic_fonts/use_oversampling=false
+rendering/fonts/dynamic_fonts/use_oversampling=false

--- a/src/Entity.gd
+++ b/src/Entity.gd
@@ -1,5 +1,6 @@
+class_name Entity
 extends Area2D
 
 
-func player_entered(_body):
+func player_entered(body: Node2D):
 	pass # Replace with function body.

--- a/src/Global.gd
+++ b/src/Global.gd
@@ -3,8 +3,7 @@ extends Node
 const SAVE_FILE = "user://savegame.save"
 const ALL_TREASURES = 9
 
-# warning-ignore:unused_signal
-signal update_treasure
+signal update_treasure()
 
 var player : Player
 var level: String = ""
@@ -21,7 +20,7 @@ func _add_item(item: String, items: Dictionary):
 		items[level].append(item)
 
 
-func add_tresure(treasure: String):
+func add_treasure(treasure: String):
 	_add_item(treasure, curr_treasures)
 
 

--- a/src/Player.gd
+++ b/src/Player.gd
@@ -1,9 +1,9 @@
 class_name Player
-extends KinematicBody2D
+extends CharacterBody2D
 
-signal player_killed
-signal won
-export (int) var speed = 100
+signal player_killed()
+signal won()
+@export var speed : int = 100
 
 var velocity := Vector2.ZERO
 var treasures := 0
@@ -14,10 +14,10 @@ func _ready():
 	Global.player = self
 
 func get_extents():
-	return $CollisionShape2D.shape.extents
+	return $CollisionShape2D.shape.size / 2.0
 
 func get_input():
-	velocity = Vector2()
+	velocity = Vector2.ZERO
 	if Input.is_action_pressed("ui_right"):
 		velocity.x += 1
 	if Input.is_action_pressed("ui_left"):
@@ -31,7 +31,7 @@ func get_input():
 
 func _physics_process(_delta):
 	get_input()
-	velocity = move_and_slide(velocity)
+	move_and_slide()
 
 
 func die(obj, signal_str):
@@ -40,19 +40,19 @@ func die(obj, signal_str):
 		set_physics_process(false)
 		print("player killed")
 		if obj != null:
-			yield(obj, signal_str)
-		emit_signal("player_killed")
+			await obj[signal_str]
+		player_killed.emit()
 
 
 # must be called during idle period
 func disable():
-	visible = false
+	hide()
 	$CollisionShape2D.disabled = true
 
 
 func enable():
 	dead = false
-	visible = true
+	show()
 	set_physics_process(true)
 	$CollisionShape2D.disabled = false
 
@@ -61,14 +61,14 @@ func count_treasures():
 	treasures = 0
 	for level in Global.treasures:
 		treasures += Global.treasures[level].size()
-	Global.emit_signal("update_treasure")
+	Global.update_treasure.emit()
 
 
 func add_treasure():
 	treasures += 1
-	Global.emit_signal("update_treasure")
+	Global.update_treasure.emit()
 	if treasures >= Global.ALL_TREASURES:
-		emit_signal("won")
+		won.emit()
 
 
 func update_camera_limits(rect : Rect2):


### PR DESCRIPTION
I've manually upgraded `project.godot` and several core scripts to improve Godot 4.x compatibility.

Here's what I've done so far:
- Updated `project.godot`:
  - `config_version` is now 5.
  - Adjusted paths for `use_pixel_snap`, window size, and font oversampling.
  - Added `rendering_method="mobile"`.
- Updated GDScripts:
  - `src/Global.gd`: Corrected a function name typo and updated signal syntax.
  - `src/Entity.gd`: Added `class_name` and updated a signal handler signature.
  - `src/Player.gd`: Changed the base class to `CharacterBody2D`, updated signal/export syntax, `move_and_slide` usage, `yield` to `await`, `emit_signal` to direct emission, and visibility calls.

This work is ongoing. I encountered a primary blocker because I couldn't use the Godot 4 automatic converter due to issues downloading the editor. Full testing and further script/scene updates are pending.